### PR TITLE
upsert with _id

### DIFF
--- a/slack-invite.js
+++ b/slack-invite.js
@@ -41,6 +41,7 @@ if (Meteor.isServer) {
           }).length;
 
           var data = {
+            _id: 'slack',
             online: active,
             registered: total
           };
@@ -57,7 +58,7 @@ if (Meteor.isServer) {
   }, 30000);
 
   Meteor.publish('slack', function() {
-    return Slack.find();
+    return Slack.find({_id:'slack'});
   });
 }
 else {


### PR DESCRIPTION
defines _id: 'slack' when the first slack record is created so that upsert works.
also modified slack's publish to return Slack.find({_id:'slack'});
